### PR TITLE
Add auto-format, split main into functions

### DIFF
--- a/dev/format.sh
+++ b/dev/format.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
+
+# Sort imports
+python -m isort efa_dti
+python -m isort utility
+
+# Format code
+python -m black -q efa_dti
+python -m black -q utility
+
+# Format docstrings
+python -m docformatter -i -r efa_dti
+python -m docformatter -i -r utility

--- a/efa_dti/efa_dti_data_module.py
+++ b/efa_dti/efa_dti_data_module.py
@@ -2,7 +2,7 @@ from typing import Callable, Optional
 
 import pytorch_lightning as pl
 from sklearn.model_selection import train_test_split
-from torch.utils.data import Subset, DataLoader
+from torch.utils.data import DataLoader, Subset
 
 from utility.dataset import EFA_DTI_Dataset
 from utility.preprocess import dgl_collate, pIC50_transform

--- a/efa_dti/efa_dti_main.py
+++ b/efa_dti/efa_dti_main.py
@@ -1,51 +1,73 @@
 import pytorch_lightning as pl
 import yaml
 from pytorch_lightning.callbacks import (
-    LearningRateMonitor,
     EarlyStopping,
+    LearningRateMonitor,
     ModelCheckpoint,
 )
 from pytorch_lightning.loggers import WandbLogger
 
-from efa_dti_data_module import EFA_DTI_DataModule
-from efa_dti_module import EFA_DTI_Module
+from .efa_dti_data_module import EFA_DTI_DataModule
+from .efa_dti_module import EFA_DTI_Module
 
-# Load configuration file(.yaml)
-with open("config/efa_dti_config.yaml") as f:
-    cfg = yaml.load(f, Loader=yaml.FullLoader)
 
-# Set parameters
-project_params = cfg["project_params"]
-module_params = cfg["module_params"]
-dataset_params = cfg["dataset_params"]
+def load_configuration():
+    # Load configuration file(.yaml)
+    with open("config/efa_dti_config.yaml") as f:
+        cfg = yaml.load(f, Loader=yaml.FullLoader)
 
-# Set model and dataloader
-net = EFA_DTI_Module(**module_params)
-data = EFA_DTI_DataModule(**dataset_params)
+    # Set parameters
+    project_params = cfg["project_params"]
+    module_params = cfg["module_params"]
+    dataset_params = cfg["dataset_params"]
 
-# Set wandb
-pl.seed_everything(project_params["seed"])
-trainer = pl.Trainer(
-    logger=WandbLogger(
-        project=project_params["project"],
-        entity=project_params["entity"],
-        log_model=True,
-    ),
-    gpus=project_params["gpus"],
-    accelerator=project_params["accelerator"],
-    max_epochs=project_params["max_epochs"],
-    callbacks=[
-        EarlyStopping(
-            patience=project_params["patience"], monitor=project_params["monitor"]
+    return project_params, module_params, dataset_params
+
+
+def load_net_and_data(module_params, dataset_params):
+    # Set model and dataloader
+    net = EFA_DTI_Module(**module_params)
+    data = EFA_DTI_DataModule(**dataset_params)
+    return net, data
+
+
+def load_trainer(project_params) -> pl.Trainer:
+    # Set wandb
+    pl.seed_everything(project_params["seed"])
+    trainer = pl.Trainer(
+        logger=WandbLogger(
+            project=project_params["project"],
+            entity=project_params["entity"],
+            log_model=True,
         ),
-        LearningRateMonitor(logging_interval=project_params["logging_interval"]),
-        ModelCheckpoint(
-            dirpath=project_params["save_path"],
-            filename="EFA_DTI_best_mse",
-            monitor=project_params["monitor"],
-            save_top_k=1,
-            mode="min",
-        ),
-    ],
-)
-trainer.fit(net, data)
+        gpus=project_params["gpus"],
+        accelerator=project_params["accelerator"],
+        max_epochs=project_params["max_epochs"],
+        callbacks=[
+            EarlyStopping(
+                patience=project_params["patience"], monitor=project_params["monitor"]
+            ),
+            LearningRateMonitor(logging_interval=project_params["logging_interval"]),
+            ModelCheckpoint(
+                dirpath=project_params["save_path"],
+                filename="EFA_DTI_best_mse",
+                monitor=project_params["monitor"],
+                save_top_k=1,
+                mode="min",
+            ),
+        ],
+    )
+    return trainer
+
+
+def main():
+    project_params, module_params, dataset_params = load_configuration()
+
+    net, data = load_net_and_data(module_params, dataset_params)
+
+    trainer = load_trainer(project_params)
+    trainer.fit(net, data)
+
+
+if __name__ == "__main__":
+    main()

--- a/utility/dataset.py
+++ b/utility/dataset.py
@@ -8,12 +8,7 @@ from ogb.utils import smiles2graph
 from torch.utils.data import Dataset
 from tqdm import tqdm
 
-from utility.preprocess import (
-    dgl_graph,
-    get_fingerprint,
-    EmbedProt,
-    pIC50_transform,
-)
+from utility.preprocess import EmbedProt, dgl_graph, get_fingerprint, pIC50_transform
 
 
 class EFA_DTI_Dataset(Dataset):

--- a/utility/layers.py
+++ b/utility/layers.py
@@ -8,7 +8,7 @@ from dgl.ops import edge_softmax
 from einops import rearrange
 from ogb.graphproppred.mol_encoder import AtomEncoder, BondEncoder
 
-from utility.norms import ReZero, GraphNormAndProj, EdgeNormWithGainAndBias
+from utility.norms import EdgeNormWithGainAndBias, GraphNormAndProj, ReZero
 
 """
 ----------------------
@@ -41,10 +41,9 @@ class GraphNetBlock(nn.Module):
         act: str = "relu",
         norm_type="gn",
     ):
-        """
-        Initialize a multi-headed attention block compatible with DGLGraph
-        inputs. Given a fully connected input graph with self loops,
-        is analogous to original Transformer.
+        """Initialize a multi-headed attention block compatible with DGLGraph
+        inputs. Given a fully connected input graph with self loops, is
+        analogous to original Transformer.
 
         Args:
             d_in: input dimension

--- a/utility/norms.py
+++ b/utility/norms.py
@@ -1,6 +1,6 @@
 import dgl
 import torch as th
-from dgl.backend.pytorch.sparse import _gsddmm, _gspmm, gspmm, gsddmm
+from dgl.backend.pytorch.sparse import _gsddmm, _gspmm, gsddmm, gspmm
 from torch import nn
 
 
@@ -149,10 +149,11 @@ def edge_norm(gidx, scores, eids=dgl.base.ALL):
 
 
 class EdgeNormWithGainAndBias(th.nn.Module):
-    """
-    Edge normalization with gain and bias per head from Richter and
-    Wattenhofer, 2020. https://arxiv.org/abs/2005.09561, adapted for graph
-    input structures.
+    """Edge normalization with gain and bias per head from Richter and
+    Wattenhofer, 2020.
+
+    https://arxiv.org/abs/2005.09561, adapted for graph input
+    structures.
     """
 
     def __init__(self, nheads: int = 1):

--- a/utility/preprocess.py
+++ b/utility/preprocess.py
@@ -6,7 +6,7 @@ import numpy as np
 import torch as th
 from rdkit import Chem
 from rdkit.Chem import AllChem, DataStructs
-from transformers import AutoTokenizer, AutoModel, pipeline
+from transformers import AutoModel, AutoTokenizer, pipeline
 
 
 def dgl_collate(batch):


### PR DESCRIPTION
This PR does three things:

1. It adds a new auto-formatting script (`/dev/format.sh`) that formats the code using `isort`/`black`/`docformatter`
2. It formats all existing code using the new script (the only diffs come from changed import order and slightly formatted docstrings)
3. It splits `efa_dti_main.py` into several functions to make the functionality reusable from other modules